### PR TITLE
proxy auth 0.13.0

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -192,7 +192,7 @@ test = {
 build_options = {"includes": ["_cffi_backend"]}
 setup(
     name="openmetadata-ingestion",
-    version="0.13.0.3.dev0",
+    version="0.13.0.3.phc0",
     url="https://open-metadata.org/",
     author="OpenMetadata Committers",
     license="Apache License 2.0",

--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -101,6 +101,8 @@ class ClientConfig(ConfigModel):
     access_token: Optional[str] = None
     expires_in: Optional[int] = None
     auth_header: Optional[str] = None
+    extra_auth_header: Optional[str] = None
+    extra_auth_header_value: Optional[str] = None
     raw_data: Optional[bool] = False
     allow_redirects: Optional[bool] = False
     auth_token_mode: Optional[str] = "Bearer"
@@ -156,6 +158,16 @@ class REST:
         headers[
             self.config.auth_header
         ] = f"{self._auth_token_mode} {self.config.access_token}"
+
+        # Include extra auth header if specified,
+        # use Authorization header value if no value is provided
+        if self.config.extra_auth_header:
+            logger.debug(
+                "Extra auth header '%s' provided", self.config.extra_auth_header
+            )
+            headers[self.config.extra_auth_header] = (
+                self.config.extra_auth_header_value or headers[self.config.auth_header]
+            )
 
         opts = {
             "headers": headers,

--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -22,6 +22,8 @@ try:
 except ImportError:
     from typing_compat import get_args
 
+from os import getenv
+
 from pydantic import BaseModel
 from requests.utils import quote
 
@@ -216,6 +218,8 @@ class OpenMetadata(
             base_url=self.config.hostPort,
             api_version=self.config.apiVersion,
             auth_header="Authorization",
+            extra_auth_header=getenv("OMETA_HEADER_EXTRA_AUTH_NAME"),
+            extra_auth_header_value=getenv("OMETA_HEADER_EXTRA_AUTH_VALUE"),
             auth_token=self._auth_provider.get_access_token,
             verify=get_verify_ssl(config),
         )


### PR DESCRIPTION
Configurable Extra Authorization Header

- Adds two new header that can be set via env-var
  (`OMETA_HEADER_EXTRA_AUTH_NAME` and `OMETA_HEADER_EXTRA_AUTH_VALUE`)
- By default, it copies the Authorization header value to the extra auth header
- If a value is specified in the corresponding env-var, that value is
  used instead of the existing token

The primary use case is for Google Cloud's Identity Aware Proxy (IAP) which allows secure access to private services but removes the Authorization header in the process. The `Proxy-Authorization` header gets forwarded along to the service as the `Authorization` header for the internal service.

[Relevant](https://stackoverflow.com/questions/59297161/using-nested-authentication-with-google-iap)
